### PR TITLE
Feature/gan metrics corrected

### DIFF
--- a/GANDLF/metrics/__init__.py
+++ b/GANDLF/metrics/__init__.py
@@ -18,7 +18,11 @@ from .segmentation import (
     jaccard,
     jaccard_per_label,
 )
-from .regression import classification_accuracy, balanced_acc_score, per_label_accuracy
+from .regression import (
+    classification_accuracy,
+    balanced_acc_score,
+    per_label_accuracy,
+)
 from .generic import (
     recall_score,
     precision_score,

--- a/GANDLF/metrics/gan_utils/fid.py
+++ b/GANDLF/metrics/gan_utils/fid.py
@@ -1,0 +1,524 @@
+from copy import deepcopy
+from typing import Any, List, Optional, Sequence, Tuple, Union
+
+import torch
+from torch import Tensor
+from torch.nn import Module
+from torch.nn.functional import adaptive_avg_pool2d, interpolate
+from acsconv.converters import (
+    ACSConverter,
+    Conv3dConverter,
+    SoftACSConverter,
+)
+from torchmetrics.metric import Metric
+from torchmetrics.utilities.imports import (
+    _MATPLOTLIB_AVAILABLE,
+    _TORCH_FIDELITY_AVAILABLE,
+)
+from torchmetrics.utilities.plot import _AX_TYPE, _PLOT_OUT_TYPE
+
+if not _MATPLOTLIB_AVAILABLE:
+    __doctest_skip__ = ["FrechetInceptionDistance.plot"]
+
+if _TORCH_FIDELITY_AVAILABLE:
+    from torch_fidelity.feature_extractor_inceptionv3 import (
+        FeatureExtractorInceptionV3 as _FeatureExtractorInceptionV3,
+    )
+    from torch_fidelity.helpers import vassert
+    from torch_fidelity.interpolate_compat_tensorflow import (
+        interpolate_bilinear_2d_like_tensorflow1x,
+    )
+else:
+
+    class _FeatureExtractorInceptionV3(Module):  # type: ignore[no-redef]
+        pass
+
+    vassert = None
+    interpolate_bilinear_2d_like_tensorflow1x = None
+
+    __doctest_skip__ = [
+        "FrechetInceptionDistance",
+        "FrechetInceptionDistance.plot",
+    ]
+
+
+class NoTrainInceptionV3(_FeatureExtractorInceptionV3):
+    """Module that never leaves evaluation mode."""
+
+    def __init__(
+        self,
+        name: str,
+        features_list: List[str],
+        feature_extractor_weights_path: Optional[str] = None,
+    ) -> None:
+        if not _TORCH_FIDELITY_AVAILABLE:
+            raise ModuleNotFoundError(
+                "NoTrainInceptionV3 module requires that `Torch-fidelity` is installed."
+                " Either install as `pip install torchmetrics[image]` or `pip install torch-fidelity`."
+            )
+
+        super().__init__(name, features_list, feature_extractor_weights_path)
+        # put into evaluation mode
+        self.eval()
+
+    def train(self, mode: bool) -> "NoTrainInceptionV3":
+        """Force network to always be in evaluation mode."""
+        return super().train(False)
+
+    def _torch_fidelity_forward(self, x: Tensor) -> Tuple[Tensor, ...]:
+        """Forward method of inception net.
+
+        Copy of the forward method from this file:
+        https://github.com/toshas/torch-fidelity/blob/master/torch_fidelity/feature_extractor_inceptionv3.py
+        with a single line change regarding the casting of `x` in the beginning.
+
+        Corresponding license file (Apache License, Version 2.0):
+        https://github.com/toshas/torch-fidelity/blob/master/LICENSE.md
+
+        """
+        vassert(
+            torch.is_tensor(x) and x.dtype == torch.uint8,
+            "Expecting image as torch.Tensor with dtype=torch.uint8",
+        )
+        features = {}
+        remaining_features = self.features_list.copy()
+
+        x = x.to(self._dtype) if hasattr(self, "_dtype") else x.to(torch.float)
+        x = interpolate_bilinear_2d_like_tensorflow1x(
+            x,
+            size=(self.INPUT_IMAGE_SIZE, self.INPUT_IMAGE_SIZE),
+            align_corners=False,
+        )
+        x = (x - 128) / 128
+
+        x = self.Conv2d_1a_3x3(x)
+        x = self.Conv2d_2a_3x3(x)
+        x = self.Conv2d_2b_3x3(x)
+        x = self.MaxPool_1(x)
+
+        if "64" in remaining_features:
+            features["64"] = (
+                adaptive_avg_pool2d(x, output_size=(1, 1))
+                .squeeze(-1)
+                .squeeze(-1)
+            )
+            remaining_features.remove("64")
+            if len(remaining_features) == 0:
+                return tuple(features[a] for a in self.features_list)
+
+        x = self.Conv2d_3b_1x1(x)
+        x = self.Conv2d_4a_3x3(x)
+        x = self.MaxPool_2(x)
+
+        if "192" in remaining_features:
+            features["192"] = (
+                adaptive_avg_pool2d(x, output_size=(1, 1))
+                .squeeze(-1)
+                .squeeze(-1)
+            )
+            remaining_features.remove("192")
+            if len(remaining_features) == 0:
+                return tuple(features[a] for a in self.features_list)
+
+        x = self.Mixed_5b(x)
+        x = self.Mixed_5c(x)
+        x = self.Mixed_5d(x)
+        x = self.Mixed_6a(x)
+        x = self.Mixed_6b(x)
+        x = self.Mixed_6c(x)
+        x = self.Mixed_6d(x)
+        x = self.Mixed_6e(x)
+
+        if "768" in remaining_features:
+            features["768"] = (
+                adaptive_avg_pool2d(x, output_size=(1, 1))
+                .squeeze(-1)
+                .squeeze(-1)
+            )
+            remaining_features.remove("768")
+            if len(remaining_features) == 0:
+                return tuple(features[a] for a in self.features_list)
+
+        x = self.Mixed_7a(x)
+        x = self.Mixed_7b(x)
+        x = self.Mixed_7c(x)
+        x = self.AvgPool(x)
+        x = torch.flatten(x, 1)
+
+        if "2048" in remaining_features:
+            features["2048"] = x
+            remaining_features.remove("2048")
+            if len(remaining_features) == 0:
+                return tuple(features[a] for a in self.features_list)
+
+        if "logits_unbiased" in remaining_features:
+            x = x.mm(self.fc.weight.T)
+            # N x 1008 (num_classes)
+            features["logits_unbiased"] = x
+            remaining_features.remove("logits_unbiased")
+            if len(remaining_features) == 0:
+                return tuple(features[a] for a in self.features_list)
+
+            x = x + self.fc.bias.unsqueeze(0)
+        else:
+            x = self.fc(x)
+
+        features["logits"] = x
+        return tuple(features[a] for a in self.features_list)
+
+    def forward(self, x: Tensor) -> Tensor:
+        """Forward pass of neural network with reshaping of output."""
+        out = self._torch_fidelity_forward(x)
+        return out[0].reshape(x.shape[0], -1)
+
+
+def _compute_fid(
+    mu1: Tensor, sigma1: Tensor, mu2: Tensor, sigma2: Tensor
+) -> Tensor:
+    r"""Compute adjusted version of `Fid Score`_.
+
+    The Frechet Inception Distance between two multivariate Gaussians X_x ~ N(mu_1, sigm_1)
+    and X_y ~ N(mu_2, sigm_2) is d^2 = ||mu_1 - mu_2||^2 + Tr(sigm_1 + sigm_2 - 2*sqrt(sigm_1*sigm_2)).
+
+    Args:
+        mu1: mean of activations calculated on predicted (x) samples
+        sigma1: covariance matrix over activations calculated on predicted (x) samples
+        mu2: mean of activations calculated on target (y) samples
+        sigma2: covariance matrix over activations calculated on target (y) samples
+
+    Returns:
+        Scalar value of the distance between sets.
+
+    """
+    a = (mu1 - mu2).square().sum(dim=-1)
+    b = sigma1.trace() + sigma2.trace()
+    c = torch.linalg.eigvals(sigma1 @ sigma2).sqrt().real.sum(dim=-1)
+
+    return a + b - 2 * c
+
+
+class FrechetInceptionDistance(Metric):
+    r"""Calculate Fréchet inception distance (FID_) which is used to access the quality of generated images.
+
+    .. math::
+        FID = \|\mu - \mu_w\|^2 + tr(\Sigma + \Sigma_w - 2(\Sigma \Sigma_w)^{\frac{1}{2}})
+
+    where :math:`\mathcal{N}(\mu, \Sigma)` is the multivariate normal distribution estimated from Inception v3
+    (`fid ref1`_) features calculated on real life images and :math:`\mathcal{N}(\mu_w, \Sigma_w)` is the
+    multivariate normal distribution estimated from Inception v3 features calculated on generated (fake) images.
+    The metric was originally proposed in `fid ref1`_.
+
+    Using the default feature extraction (Inception v3 using the original weights from `fid ref2`_), the input is
+    expected to be mini-batches of 3-channel RGB images of shape ``(3xHxW)``. If argument ``normalize``
+    is ``True`` images are expected to be dtype ``float`` and have values in the ``[0,1]`` range, else if
+    ``normalize`` is set to ``False`` images are expected to have dtype ``uint8`` and take values in the ``[0, 255]``
+    range. All images will be resized to 299 x 299 which is the size of the original training data. The boolian
+    flag ``real`` determines if the images should update the statistics of the real distribution or the
+    fake distribution.
+
+    This metric is known to be unstable in its calculatations, and we recommend for the best results using this metric
+    that you calculate using `torch.float64` (default is `torch.float32`) which can be set using the `.set_dtype`
+    method of the metric.
+
+    .. note:: using this metrics requires you to have torch 1.9 or higher installed
+
+    .. note:: using this metric with the default feature extractor requires that ``torch-fidelity``
+        is installed. Either install as ``pip install torchmetrics[image]`` or ``pip install torch-fidelity``
+
+    As input to ``forward`` and ``update`` the metric accepts the following input
+
+    - ``imgs`` (:class:`~torch.Tensor`): tensor with images feed to the feature extractor with
+    - ``real`` (:class:`~bool`): bool indicating if ``imgs`` belong to the real or the fake distribution
+
+    As output of `forward` and `compute` the metric returns the following output
+
+    - ``fid`` (:class:`~torch.Tensor`): float scalar tensor with mean FID value over samples
+
+    Args:
+        feature:
+            Either an integer or ``nn.Module``:
+
+            - an integer will indicate the inceptionv3 feature layer to choose. Can be one of the following:
+              64, 192, 768, 2048
+            - an ``nn.Module`` for using a custom feature extractor. Expects that its forward method returns
+              an ``(N,d)`` matrix where ``N`` is the batch size and ``d`` is the feature size.
+
+        reset_real_features: Whether to also reset the real features. Since in many cases the real dataset does not
+            change, the features can be cached them to avoid recomputing them which is costly. Set this to ``False`` if
+            your dataset does not change.
+        kwargs: Additional keyword arguments, see :ref:`Metric kwargs` for more info.
+
+    .. note::
+        If a custom feature extractor is provided through the `feature` argument it is expected to either have a
+        attribute called ``num_features`` that indicates the number of features returned by the forward pass or
+        alternatively we will pass through tensor of shape ``(1, 3, 299, 299)`` and dtype ``torch.uint8``` to the
+        forward pass and expect a tensor of shape ``(1, num_features)`` as output.
+
+    Raises:
+        ValueError:
+            If torch version is lower than 1.9
+        ModuleNotFoundError:
+            If ``feature`` is set to an ``int`` (default settings) and ``torch-fidelity`` is not installed
+        ValueError:
+            If ``feature`` is set to an ``int`` not in [64, 192, 768, 2048]
+        TypeError:
+            If ``feature`` is not an ``str``, ``int`` or ``torch.nn.Module``
+        ValueError:
+            If ``reset_real_features`` is not an ``bool``
+
+    Example:
+        >>> import torch
+        >>> _ = torch.manual_seed(123)
+        >>> from torchmetrics.image.fid import FrechetInceptionDistance
+        >>> fid = FrechetInceptionDistance(feature=64)
+        >>> # generate two slightly overlapping image intensity distributions
+        >>> imgs_dist1 = torch.randint(0, 200, (100, 3, 299, 299), dtype=torch.uint8)
+        >>> imgs_dist2 = torch.randint(100, 255, (100, 3, 299, 299), dtype=torch.uint8)
+        >>> fid.update(imgs_dist1, real=True)
+        >>> fid.update(imgs_dist2, real=False)
+        >>> fid.compute()
+        tensor(12.7202)
+
+    """
+
+    higher_is_better: bool = False
+    is_differentiable: bool = False
+    full_state_update: bool = False
+    plot_lower_bound: float = 0.0
+
+    real_features_sum: Tensor
+    real_features_cov_sum: Tensor
+    real_features_num_samples: Tensor
+
+    fake_features_sum: Tensor
+    fake_features_cov_sum: Tensor
+    fake_features_num_samples: Tensor
+
+    inception: Module
+    feature_network: str = "inception"
+
+    def __init__(
+        self,
+        feature: Union[int, Module] = 2048,
+        reset_real_features: bool = True,
+        normalize: bool = False,
+        **kwargs: Any,
+    ) -> None:
+        super().__init__(**kwargs)
+        if isinstance(feature, int):
+            num_features = feature
+            if not _TORCH_FIDELITY_AVAILABLE:
+                raise ModuleNotFoundError(
+                    "FrechetInceptionDistance metric requires that `Torch-fidelity` is installed."
+                    " Either install as `pip install torchmetrics[image]` or `pip install torch-fidelity`."
+                )
+            valid_int_input = (64, 192, 768, 2048)
+            if feature not in valid_int_input:
+                raise ValueError(
+                    f"Integer input to argument `feature` must be one of {valid_int_input}, but got {feature}."
+                )
+
+            self.inception = NoTrainInceptionV3(
+                name="inception-v3-compat", features_list=[str(feature)]
+            )
+
+        elif isinstance(feature, Module):
+            self.inception = feature
+            if hasattr(self.inception, "num_features"):
+                num_features = self.inception.num_features
+            else:
+                dummy_image = torch.randint(
+                    0, 255, (1, 3, 299, 299), dtype=torch.uint8
+                )
+                num_features = self.inception(dummy_image).shape[-1]
+        else:
+            raise TypeError("Got unknown input to argument `feature`")
+
+        if not isinstance(reset_real_features, bool):
+            raise ValueError(
+                "Argument `reset_real_features` expected to be a bool"
+            )
+        self.reset_real_features = reset_real_features
+
+        if not isinstance(normalize, bool):
+            raise ValueError("Argument `normalize` expected to be a bool")
+        self.normalize = normalize
+
+        mx_num_feats = (num_features, num_features)
+        self.add_state(
+            "real_features_sum",
+            torch.zeros(num_features).double(),
+            dist_reduce_fx="sum",
+        )
+        self.add_state(
+            "real_features_cov_sum",
+            torch.zeros(mx_num_feats).double(),
+            dist_reduce_fx="sum",
+        )
+        self.add_state(
+            "real_features_num_samples",
+            torch.tensor(0).long(),
+            dist_reduce_fx="sum",
+        )
+
+        self.add_state(
+            "fake_features_sum",
+            torch.zeros(num_features).double(),
+            dist_reduce_fx="sum",
+        )
+        self.add_state(
+            "fake_features_cov_sum",
+            torch.zeros(mx_num_feats).double(),
+            dist_reduce_fx="sum",
+        )
+        self.add_state(
+            "fake_features_num_samples",
+            torch.tensor(0).long(),
+            dist_reduce_fx="sum",
+        )
+
+    def update(self, imgs: Tensor, real: bool) -> None:
+        """Update the state with extracted features."""
+        imgs = (imgs * 255).byte() if self.normalize else imgs
+        features = self.inception(imgs)
+        self.orig_dtype = features.dtype
+        features = features.double()
+
+        if features.dim() == 1:
+            features = features.unsqueeze(0)
+        if real:
+            self.real_features_sum += features.sum(dim=0)
+            self.real_features_cov_sum += features.t().mm(features)
+            self.real_features_num_samples += imgs.shape[0]
+        else:
+            self.fake_features_sum += features.sum(dim=0)
+            self.fake_features_cov_sum += features.t().mm(features)
+            self.fake_features_num_samples += imgs.shape[0]
+
+    def compute(self) -> Tensor:
+        """Calculate FID score based on accumulated extracted features from the two distributions."""
+        if (
+            self.real_features_num_samples < 2
+            or self.fake_features_num_samples < 2
+        ):
+            raise RuntimeError(
+                "More than one sample is required for both the real and fake distributed to compute FID"
+            )
+        mean_real = (
+            self.real_features_sum / self.real_features_num_samples
+        ).unsqueeze(0)
+        mean_fake = (
+            self.fake_features_sum / self.fake_features_num_samples
+        ).unsqueeze(0)
+
+        cov_real_num = (
+            self.real_features_cov_sum
+            - self.real_features_num_samples * mean_real.t().mm(mean_real)
+        )
+        cov_real = cov_real_num / (self.real_features_num_samples - 1)
+        cov_fake_num = (
+            self.fake_features_cov_sum
+            - self.fake_features_num_samples * mean_fake.t().mm(mean_fake)
+        )
+        cov_fake = cov_fake_num / (self.fake_features_num_samples - 1)
+        return _compute_fid(
+            mean_real.squeeze(0), cov_real, mean_fake.squeeze(0), cov_fake
+        ).to(self.orig_dtype)
+
+    def reset(self) -> None:
+        """Reset metric states."""
+        if not self.reset_real_features:
+            real_features_sum = deepcopy(self.real_features_sum)
+            real_features_cov_sum = deepcopy(self.real_features_cov_sum)
+            real_features_num_samples = deepcopy(
+                self.real_features_num_samples
+            )
+            super().reset()
+            self.real_features_sum = real_features_sum
+            self.real_features_cov_sum = real_features_cov_sum
+            self.real_features_num_samples = real_features_num_samples
+        else:
+            super().reset()
+
+    def set_dtype(self, dst_type: Union[str, torch.dtype]) -> "Metric":
+        """Transfer all metric state to specific dtype. Special version of standard `type` method.
+
+        Arguments:
+            dst_type: the desired type as ``torch.dtype`` or string
+
+        """
+        out = super().set_dtype(dst_type)
+        if isinstance(out.inception, NoTrainInceptionV3):
+            out.inception._dtype = dst_type
+        return out
+
+    def plot(
+        self,
+        val: Optional[Union[Tensor, Sequence[Tensor]]] = None,
+        ax: Optional[_AX_TYPE] = None,
+    ) -> _PLOT_OUT_TYPE:
+        """Plot a single or multiple values from the metric.
+
+        Args:
+            val: Either a single result from calling `metric.forward` or `metric.compute` or a list of these results.
+                If no value is provided, will automatically call `metric.compute` and plot that result.
+            ax: An matplotlib axis object. If provided will add plot to that axis
+
+        Returns:
+            Figure and Axes object
+
+        Raises:
+            ModuleNotFoundError:
+                If `matplotlib` is not installed
+
+        .. plot::
+            :scale: 75
+
+            >>> # Example plotting a single value
+            >>> import torch
+            >>> from torchmetrics.image.fid import FrechetInceptionDistance
+            >>> imgs_dist1 = torch.randint(0, 200, (100, 3, 299, 299), dtype=torch.uint8)
+            >>> imgs_dist2 = torch.randint(100, 255, (100, 3, 299, 299), dtype=torch.uint8)
+            >>> metric = FrechetInceptionDistance(feature=64)
+            >>> metric.update(imgs_dist1, real=True)
+            >>> metric.update(imgs_dist2, real=False)
+            >>> fig_, ax_ = metric.plot()
+
+        .. plot::
+            :scale: 75
+
+            >>> # Example plotting multiple values
+            >>> import torch
+            >>> from torchmetrics.image.fid import FrechetInceptionDistance
+            >>> imgs_dist1 = lambda: torch.randint(0, 200, (100, 3, 299, 299), dtype=torch.uint8)
+            >>> imgs_dist2 = lambda: torch.randint(100, 255, (100, 3, 299, 299), dtype=torch.uint8)
+            >>> metric = FrechetInceptionDistance(feature=64)
+            >>> values = [ ]
+            >>> for _ in range(3):
+            ...     metric.update(imgs_dist1(), real=True)
+            ...     metric.update(imgs_dist2(), real=False)
+            ...     values.append(metric.compute())
+            ...     metric.reset()
+            >>> fig_, ax_ = metric.plot(values)
+
+        """
+        return self._plot(val, ax)
+
+
+if __name__ == "__main__":
+    rand_img_1 = torch.randint(0, 255, (10, 3, 100, 100), dtype=torch.uint8)
+    rand_img_2 = torch.randint(0, 255, (10, 3, 100, 100), dtype=torch.uint8)
+    metric = FrechetInceptionDistance(feature=64)
+    print(metric.inception)
+    converter = SoftACSConverter(metric.inception)
+    print(converter)
+    # metric.update(rand_img_1, real=True)
+    # metric.update(rand_img_2, real=False)
+    # print(metric.compute())
+    # import torchvision
+
+    # net = torchvision.models.inception_v3(
+    #     torchvision.models.Inception_V3_Weights.IMAGENET1K_V1
+    # )
+    # print(net)
+    # converter = SoftACSConverter(net)

--- a/GANDLF/metrics/gan_utils/functional/__init__.py
+++ b/GANDLF/metrics/gan_utils/functional/__init__.py
@@ -1,0 +1,8 @@
+from .lpips import (
+    determine_converter,
+    modify_net_input,
+    lpips_compute,
+    lpips_update,
+    modify_scaling_layer,
+    _NoTrainLpipsLPIPSGandlf,
+)

--- a/GANDLF/metrics/gan_utils/functional/lpips.py
+++ b/GANDLF/metrics/gan_utils/functional/lpips.py
@@ -1,0 +1,367 @@
+import os
+import torch
+from torch import nn
+from torch import Tensor
+import torchmetrics.functional.image as tm_image
+from torchmetrics.functional.image.lpips import (
+    Alexnet,
+    Vgg16,
+    SqueezeNet,
+    NetLinLayer,
+    ScalingLayer,
+)
+from typing import Tuple, Union, Literal, Optional, List
+from acsconv.converters import (
+    ACSConverter,
+    Conv3dConverter,
+    SoftACSConverter,
+)
+
+
+def _spatial_average(
+    in_tens: Tensor, n_dims: int, keep_dim: bool = True
+) -> Tensor:
+    """Spatial averaging over height and width of images."""
+
+    if n_dims == 3:
+        return in_tens.mean([2, 3, 4], keepdim=keep_dim)
+    return in_tens.mean([2, 3], keepdim=keep_dim)
+
+
+def _upsample(in_tens: Tensor, out_hw: Tuple[int, ...] = (64, 64)) -> Tensor:
+    """Upsample input with bilinear interpolation."""
+    return nn.Upsample(size=out_hw, mode="bilinear", align_corners=False)(
+        in_tens
+    )
+
+
+def _normalize_tensor(in_feat: Tensor, eps: float = 1e-8) -> Tensor:
+    """Normalize input tensor."""
+    norm_factor = torch.sqrt(
+        eps + torch.sum(in_feat**2, dim=1, keepdim=True)
+    )
+    return in_feat / norm_factor
+
+
+def _resize_tensor(x: Tensor, size: int = 64) -> Tensor:
+    """https://github.com/toshas/torch-fidelity/blob/master/torch_fidelity/sample_similarity_lpips.py#L127C22-L132."""
+    if x.shape[-1] > size and x.shape[-2] > size:
+        return torch.nn.functional.interpolate(x, (size, size), mode="area")
+    return torch.nn.functional.interpolate(
+        x, (size, size), mode="bilinear", align_corners=False
+    )
+
+
+class _LPIPSGandlf(nn.Module):
+    def __init__(
+        self,
+        n_dim: int = 2,
+        pretrained: bool = True,
+        net: Literal["alex", "vgg", "squeeze"] = "alex",
+        spatial: bool = False,
+        pnet_rand: bool = False,
+        pnet_tune: bool = False,
+        use_dropout: bool = True,
+        model_path: Optional[str] = None,
+        eval_mode: bool = True,
+        resize: Optional[int] = None,
+        **kwargs,
+    ):
+        super().__init__()
+        self.pnet_type = net
+        self.pnet_tune = pnet_tune
+        self.pnet_rand = pnet_rand
+        self.spatial = spatial
+        self.resize = resize
+
+        self.scaling_layer = ScalingLayer()
+
+        if self.pnet_type in ["vgg", "vgg16"]:
+            net_type = Vgg16
+            self.chns = [64, 128, 256, 512, 512]
+        elif self.pnet_type == "alex":
+            net_type = Alexnet  # type: ignore[assignment]
+            self.chns = [64, 192, 384, 256, 256]
+        elif self.pnet_type == "squeeze":
+            net_type = SqueezeNet  # type: ignore[assignment]
+            self.chns = [64, 128, 256, 384, 384, 512, 512]
+        self.L = len(self.chns)
+
+        self.net = net_type(
+            pretrained=not self.pnet_rand, requires_grad=self.pnet_tune
+        )
+
+        self.lin0 = NetLinLayer(self.chns[0], use_dropout=use_dropout)
+        self.lin1 = NetLinLayer(self.chns[1], use_dropout=use_dropout)
+        self.lin2 = NetLinLayer(self.chns[2], use_dropout=use_dropout)
+        self.lin3 = NetLinLayer(self.chns[3], use_dropout=use_dropout)
+        self.lin4 = NetLinLayer(self.chns[4], use_dropout=use_dropout)
+        self.lins = [self.lin0, self.lin1, self.lin2, self.lin3, self.lin4]
+        if self.pnet_type == "squeeze":  # 7 layers for squeezenet
+            self.lin5 = NetLinLayer(self.chns[5], use_dropout=use_dropout)
+            self.lin6 = NetLinLayer(self.chns[6], use_dropout=use_dropout)
+            self.lins += [self.lin5, self.lin6]
+        self.lins = nn.ModuleList(self.lins)  # type: ignore[assignment]
+        if pretrained:
+            if model_path is None:
+                model_path = os.path.abspath(
+                    os.path.join(os.path.abspath(tm_image.__file__), "..", f"lpips_models/{net}.pth")  # type: ignore[misc]
+                )
+
+            self.load_state_dict(
+                torch.load(model_path, map_location="cpu"), strict=False
+            )
+
+        if eval_mode:
+            self.eval()
+
+        self.n_dim = n_dim
+
+    @torch.no_grad
+    def forward(
+        self,
+        in0: Tensor,
+        in1: Tensor,
+        retperlayer: bool = False,
+        normalize: bool = False,
+    ) -> Union[Tensor, Tuple[Tensor, List[Tensor]]]:
+        if (
+            normalize
+        ):  # turn on this flag if input is [0,1] so it can be adjusted to [-1, +1]
+            in0 = 2 * in0 - 1
+            in1 = 2 * in1 - 1
+
+        # normalize input
+        in0_input, in1_input = self.scaling_layer(in0), self.scaling_layer(in1)
+
+        # resize input if needed
+        if self.resize is not None:
+            in0_input = _resize_tensor(in0_input, size=self.resize)
+            in1_input = _resize_tensor(in1_input, size=self.resize)
+
+        outs0, outs1 = self.net.forward(in0_input), self.net.forward(in1_input)
+        feats0, feats1, diffs = {}, {}, {}
+
+        for kk in range(self.L):
+            feats0[kk], feats1[kk] = _normalize_tensor(
+                outs0[kk]
+            ), _normalize_tensor(outs1[kk])
+            diffs[kk] = (feats0[kk] - feats1[kk]) ** 2
+
+        res = []
+        for kk in range(self.L):
+            if self.spatial:
+                res.append(
+                    _upsample(
+                        self.lins[kk](diffs[kk]), out_hw=tuple(in0.shape[2:])
+                    )
+                )
+            else:
+                res.append(
+                    _spatial_average(
+                        self.lins[kk](diffs[kk]),
+                        n_dims=self.n_dim,
+                        keep_dim=True,
+                    )
+                )
+        val: Tensor = sum(res)  # type: ignore[assignment]
+        if retperlayer:
+            return (val, res)
+        return val
+
+
+class _NoTrainLpipsLPIPSGandlf(_LPIPSGandlf):
+    """A wrapper that implements the LPIPS metric from torchmetrics to
+    handle both 2D and 3D images, single and multi-channel images."""
+
+    def train(self, mode: bool) -> "_NoTrainLpipsLPIPSGandlf":  # type: ignore[override]
+        """Force network to always be in evaluation mode."""
+        return super().train(False)
+
+
+def _valid_img(img: Tensor, normalize: bool) -> bool:
+    """Check if input is valid.
+    Args:
+        img: input image
+        normalize: whether to normalize the image
+    Returns:
+        bool: whether input is valid
+    """
+    value_check = value_check = (
+        img.max() <= 1.0 and img.min() >= 0.0 if normalize else img.min() >= -1
+    )
+    return (img.ndim == 4 or img.ndim == 5) and value_check
+
+
+def lpips_update(
+    img1: Tensor, img2: Tensor, net: nn.Module, normalize: bool
+) -> Tuple[Tensor, Union[int, Tensor]]:
+    """Update internal states with lpips score.
+    Args:
+        img1: first set of images
+        img2: second set of images
+        net: network
+        normalize: whether the network expects input to be normalized
+    Returns:
+        Tuple[Tensor, Union[int, Tensor]]: loss and total number of images
+
+    """
+    if not (_valid_img(img1, normalize) and _valid_img(img2, normalize)):
+        raise ValueError(
+            "Expected both inputs to be 4D or 5D with shape "
+            "[N x C x H x W] or [N x C x D x H x W]"
+            f"Got input with shape {img1.shape} and {img2.shape}."
+            f" {[img1.min(), img1.max()]} and {[img2.min(), img2.max()]} "
+            f" when all values are expected to be in the "
+            f"{[0,1] if normalize else [-1,1]} range."
+        )
+
+    loss = net(img1, img2, normalize=normalize).squeeze()
+    return loss, img1.shape[0]
+
+
+def lpips_compute(
+    sum_scores: Tensor,
+    total: Union[Tensor, int],
+    reduction: Literal["sum", "mean"] = "mean",
+) -> Tensor:
+    """Compute the final LPIPS score.
+    Args:
+        sum_scores: sum of all scores
+        total: total number of images
+        reduction: reduction type, one of 'mean' or 'sum'. Defaults to 'mean'.
+    Returns:
+        Tensor: final LPIPS score
+    """
+    return sum_scores / total if reduction == "mean" else sum_scores
+
+
+def determine_converter(
+    converter_type: Union[str, None]
+) -> Union[None, SoftACSConverter, ACSConverter, Conv3dConverter]:
+    """Determine the converter type to use for 2D to 3D conversion.
+    Args:
+        converter_type: str indicating the type of converter to use for
+    converting the net into a 3D network if the input is 5D. Choose
+    between `'soft'`, `'asc'` or `'conv3d'`. If ``None`` will use
+    `'soft'` by default.
+    Returns:
+        Union[None, SoftACSConverter, ACSConverter, Conv3dConverter]: the
+    converter to use.
+    """
+    if converter_type is None or converter_type == "soft":
+        converter = SoftACSConverter
+    elif converter_type == "acs":
+        converter = ACSConverter
+    elif converter_type == "conv3d":
+        converter = Conv3dConverter
+    else:
+        raise ValueError(f"Unknown converter type {converter}")
+    return converter
+
+
+def modify_net_input(
+    net: nn.Module,
+    net_type: Literal["alex", "vgg", "squeeze"],
+    n_channels: int,
+) -> None:
+    """Modify the input layer of the network to accept the correct number
+    of channels.
+    Args:
+        net: network
+        net_type: network type
+        n_channels: number of channels
+    """
+    if net_type == "squeeze":
+        net.net.slices._modules["0"]._modules["0"] = torch.nn.Conv2d(
+            n_channels,
+            64,
+            kernel_size=(3, 3),
+            stride=(2, 2),
+        )
+    elif net_type == "alex":
+        net.net._modules["slice1"]._modules["0"] = torch.nn.Conv2d(
+            n_channels,
+            64,
+            kernel_size=(11, 11),
+            stride=(4, 4),
+        )
+
+    elif net_type == "vgg":
+        net.net._modules["slice1"]._modules["0"] = torch.nn.Conv2d(
+            n_channels,
+            64,
+            kernel_size=(3, 3),
+            stride=(1, 1),
+            padding=(1, 1),
+        )
+
+
+def modify_scaling_layer(net: nn.Module) -> None:
+    """Modify the scaling layer of the network to Identity for
+    cases other than 2D 3-channel images.
+    Args:
+        net: network
+    """
+    if isinstance(net.scaling_layer, ScalingLayer):
+        net.scaling_layer = nn.Identity()
+
+
+def learned_perceptual_image_patch_similarity(
+    img1: Tensor,
+    img2: Tensor,
+    net_type: Literal["alex", "vgg", "squeeze"] = "alex",
+    reduction: Literal["sum", "mean"] = "mean",
+    normalize: bool = False,
+    n_dim: int = 2,
+    n_channels: int = 1,
+    converter_type: Union[str, None] = None,
+) -> Tensor:
+    """Functional Interface for The Learned Perceptual Image Patch Similarity
+    (`LPIPS_`) calculates perceptual similarity between two images.
+
+    LPIPS essentially computes the similarity between the activations of
+    two image patches for some pre-defined network. This measure has been
+    shown to match human perception well. A low LPIPS score means that
+    image patches are perceptual similar.
+
+    Both input image patches are expected to have shape ``(N, C, H, W)``
+    or ``(N, C, D, H, W)``.
+    The minimum size of `H, W` depends on the chosen backbone (see `net_type` arg).
+
+    Args:
+        img1: first set of images
+        img2: second set of images
+        net_type: str indicating backbone network type to use. Choose
+    `'squeeze'`, not implemented for `alex` or `vgg`.
+        reduction: str indicating how to reduce over the batch dimension.
+     Choose between `'sum'` or `'mean'`.
+        normalize: by default this is ``False`` meaning that the input is
+    expected to be in the [-1,1] range. If set to ``True`` will instead
+    expect input to be in the ``[0,1]`` range.
+        converter_type: str indicating the type of converter to use for
+    converting the net into a 3D network if the input is 5D. Choose
+    between `'soft'`, `'acs'`, `'conv3d'`. If ``None`` will use
+    `'soft'` by default.
+
+    Example:
+        >>> import torch
+        >>> _ = torch.manual_seed(123)
+        >>> from torchmetrics.functional.image.lpips import learned_perceptual_image_patch_similarity
+        >>> img1 = (torch.rand(10, 3, 100, 100) * 2) - 1
+        >>> img2 = (torch.rand(10, 3, 100, 100) * 2) - 1
+        >>> learned_perceptual_image_patch_similarity(img1, img2, net_type='squeeze')
+        tensor(0.1008, grad_fn=<DivBackward0>)
+    """
+    net = _NoTrainLpipsLPIPSGandlf(n_dim=n_dim, net=net_type).to(
+        device=img1.device, dtype=img1.dtype
+    )
+    if n_channels != 3:
+        modify_scaling_layer(net)
+        modify_net_input(net, net_type, n_channels)
+    if n_dim == 3:
+        modify_scaling_layer(net)
+        converter = determine_converter(converter_type)
+        net = converter(net)
+    loss, total = lpips_update(img1, img2, net, normalize)
+    return lpips_compute(loss.sum(), total, reduction)

--- a/GANDLF/metrics/gan_utils/lpip.py
+++ b/GANDLF/metrics/gan_utils/lpip.py
@@ -145,27 +145,3 @@ class LPIPSGandlf(Metric):
 
         """
         return self._plot(val, ax)
-
-
-if __name__ == "__main__":
-    lpip = LPIPSGandlf(
-        n_dim=3,
-        n_channels=3,
-        net_type="squeeze",
-        normalize=False,
-    )
-    rand_input_1 = (torch.rand(10, 3, 100, 100) * 2) - 1
-    rand_input_2 = (torch.rand(10, 3, 100, 100) * 2) - 1
-    # with torch.no_grad():
-    print(lpip(rand_input_1, rand_input_2))
-
-    import torchmetrics
-
-    lpips_metric = (
-        torchmetrics.image.lpip.LearnedPerceptualImagePatchSimilarity(
-            net_type="squeeze",
-            normalize=False,
-            reduction="mean",
-        )
-    )
-    print(lpips_metric(rand_input_1, rand_input_2))

--- a/GANDLF/metrics/gan_utils/lpip.py
+++ b/GANDLF/metrics/gan_utils/lpip.py
@@ -1,0 +1,171 @@
+from typing import Any, ClassVar, List, Optional, Sequence, Union
+from typing_extensions import Literal
+
+import torch
+from torch import Tensor
+from torchmetrics.utilities.plot import _AX_TYPE, _PLOT_OUT_TYPE
+from torchmetrics.metric import Metric
+
+from .functional import (
+    lpips_compute,
+    lpips_update,
+    determine_converter,
+    modify_net_input,
+    modify_scaling_layer,
+    _NoTrainLpipsLPIPSGandlf,
+)
+
+
+class LPIPSGandlf(Metric):
+    is_differentiable: bool = True
+    higher_is_better: bool = False
+    full_state_update: bool = False
+    plot_lower_bound: float = 0.0
+    plot_upper_bound: float = 1.0
+
+    sum_scores: Tensor
+    total: Tensor
+    feature_network: str = "net"
+
+    # due to the use of named tuple in the backbone the net variable cannot be scripted
+    __jit_ignored_attributes__: ClassVar[List[str]] = ["net"]
+
+    def __init__(
+        self,
+        net_type: Literal["vgg", "alex", "squeeze"] = "alex",
+        reduction: Literal["sum", "mean"] = "mean",
+        normalize: bool = False,
+        n_dim: int = 2,
+        n_channels: int = 1,
+        converter_type: Union[str, None] = None,
+        **kwargs: Any,
+    ):
+        """Initialize the LPIPS metric for GanDLF. This metric is based on the
+        torchmetrics implementation of LPIPS, with modifications to allow usage
+        of single channel data and 3D data. Note that it uses the pre-trained
+        model from the torchmetrics implementation, originally designed
+        for 3-channel 2D data. Here the layers are modified, so results need
+        to be interpreted with caution. For 2D 3-channel data, the results
+        are expected to be similar to the original implementation.
+        Args:
+            net_type (Literal["vgg", "alex", "squeeze"]): The network type.
+            reduction (Literal["sum", "mean"]): The reduction type, one of 'mean' or 'sum'
+            normalize (bool): Whether to normalize the input images.
+            n_dim (int): The number of dimensions of the input images.
+            n_channels (int): The number of channels of the input images.
+            converter_type (Union[str, None]): The converter type from ACS, one of
+        'soft','asc' or 'conv3d'. If None, defaults to 'soft'.
+            **kwargs: Additional arguments for the metric.
+        """
+
+        super().__init__(**kwargs)
+
+        valid_net_type = ("vgg", "alex", "squeeze")
+        if net_type not in valid_net_type:
+            raise ValueError(
+                f"Argument `net_type` must be one of {valid_net_type}, but got {net_type}."
+            )
+        self.net = _NoTrainLpipsLPIPSGandlf(n_dim=n_dim, net=net_type)
+
+        valid_reduction = ("mean", "sum")
+        if reduction not in valid_reduction:
+            raise ValueError(
+                f"Argument `reduction` must be one of {valid_reduction}, but got {reduction}"
+            )
+        self.reduction = reduction
+
+        if not isinstance(normalize, bool):
+            raise ValueError(
+                f"Argument `normalize` should be an bool but got {normalize}"
+            )
+        self.normalize = normalize
+
+        self.add_state("sum_scores", torch.tensor(0.0), dist_reduce_fx="sum")
+        self.add_state("total", torch.tensor(0.0), dist_reduce_fx="sum")
+        if n_channels != 3:
+            modify_scaling_layer(self.net)
+            modify_net_input(self.net, net_type, n_channels)
+        if n_dim == 3:
+            modify_scaling_layer(self.net)
+            converter = determine_converter(converter_type)
+            converter(self.net)
+
+    def update(self, img1: Tensor, img2: Tensor) -> None:
+        """Update internal states with lpips score."""
+        loss, total = lpips_update(
+            img1, img2, net=self.net, normalize=self.normalize
+        )
+        self.sum_scores += loss.sum()
+        self.total += total
+
+    def compute(self) -> Tensor:
+        """Compute final perceptual similarity metric."""
+        return lpips_compute(self.sum_scores, self.total, self.reduction)
+
+    def plot(
+        self,
+        val: Optional[Union[Tensor, Sequence[Tensor]]] = None,
+        ax: Optional[_AX_TYPE] = None,
+    ) -> _PLOT_OUT_TYPE:
+        """Plot a single or multiple values from the metric.
+
+        Args:
+            val: Either a single result from calling `metric.forward` or `metric.compute` or a list of these results.
+                If no value is provided, will automatically call `metric.compute` and plot that result.
+            ax: An matplotlib axis object. If provided will add plot to that axis
+
+        Returns:
+            Figure and Axes object
+
+        Raises:
+            ModuleNotFoundError:
+                If `matplotlib` is not installed
+
+        .. plot::
+            :scale: 75
+
+            >>> # Example plotting a single value
+            >>> import torch
+            >>> from GANDLF.metrics.gan_utils.lpip import LPIPSGandlf
+            >>> metric = LPIPSGandlf(n_dim=2, n_channels=3, net_type='squeeze')
+            >>> metric.update(torch.rand(10, 3, 100, 100), torch.rand(10, 3, 100, 100))
+            >>> fig_, ax_ = metric.plot()
+
+        .. plot::
+            :scale: 75
+
+            >>> # Example plotting multiple values
+            >>> import torch
+            >>> from GANDLF.metrics.gan_utils.lpip import LPIPSGandlf
+            >>> metric = LPIPSGandlf(n_dim=2, n_channels=3, net_type='squeeze')
+            >>> values = [ ]
+            >>> for _ in range(3):
+            ...     values.append(metric(torch.rand(10, 3, 100, 100), torch.rand(10, 3, 100, 100)))
+            >>> fig_, ax_ = metric.plot(values)
+
+        """
+        return self._plot(val, ax)
+
+
+if __name__ == "__main__":
+    lpip = LPIPSGandlf(
+        n_dim=3,
+        n_channels=3,
+        net_type="squeeze",
+        normalize=False,
+    )
+    rand_input_1 = (torch.rand(10, 3, 100, 100) * 2) - 1
+    rand_input_2 = (torch.rand(10, 3, 100, 100) * 2) - 1
+    # with torch.no_grad():
+    print(lpip(rand_input_1, rand_input_2))
+
+    import torchmetrics
+
+    lpips_metric = (
+        torchmetrics.image.lpip.LearnedPerceptualImagePatchSimilarity(
+            net_type="squeeze",
+            normalize=False,
+            reduction="mean",
+        )
+    )
+    print(lpips_metric(rand_input_1, rand_input_2))

--- a/GANDLF/metrics/generation.py
+++ b/GANDLF/metrics/generation.py
@@ -1,0 +1,160 @@
+import torch
+import torchmetrics as tm
+import warnings
+from typing import Any, Dict, List, Optional, Tuple, Union
+
+
+def overall_stats(
+    generated_images: torch.Tensor,
+    real_images: torch.Tensor,
+    params: Dict[str, Any],
+):
+    """
+    Generates a dictionary of metrics calculated on the overall generated
+    images and real images.
+    Args:
+        generated_images (torch.Tensor): The generated images.
+        real_images (torch.Tensor): The real images.
+        params (dict): The parameter dictionary containing training and data
+    information.
+    Returns:
+        dict: A dictionary of metrics.
+    """
+    assert (
+        params["problem_type"] == "synthesis"
+    ), "Only synthesis is supported for these stats"
+    output_metrics = {}
+    reduction_types_keys = {
+        "elementwise_mean": "elementwise_mean",
+        "none": "none",
+        "sum": "sum",
+    }
+    # TODO
+
+
+def _calculator_ssim(
+    generated_images: torch.Tensor,
+    real_images: torch.Tensor,
+    reduction: str,
+) -> torch.Tensor:
+    """
+    This function computes the SSIM between the generated images and the real
+    images. Except for the params specified below, the rest of the params are
+    default from torchmetrics.
+    Args:
+        generated_images (torch.Tensor): The generated images.
+        real_images (torch.Tensor): The real images.
+        reduction (str): The reduction type.
+    Returns:
+        torch.Tensor: The SSIM score.
+    """
+    ssim = tm.image.StructuralSimilarityIndexMeasure(reduction=reduction)
+    return ssim(generated_images, real_images)
+
+
+def _calculator_FID(
+    generated_images: torch.Tensor,
+    real_images: torch.Tensor,
+    n_input_channels: int,
+) -> torch.Tensor:
+    """This function computes the FID between the generated images and the
+    real images. Except for the params specified below, the rest of the params
+    are default from torchmetrics.
+    Args:
+        generated_images (torch.Tensor): The generated images.
+        real_images (torch.Tensor): The real images.
+        n_input_channels (int): The number of input channels.
+    Returns:
+        torch.Tensor: The FID score.
+    """
+    fid_metric = tm.image.fid.FrechetInceptionDistance(
+        feature=1024,
+        normalize=True,
+    )
+    if n_input_channels == 1:
+        # need manual patching for single channel data
+        fid_metric.get_submodule("inception")._modules[
+            "Conv2d_1a_3x3"
+        ]._modules["conv"] = torch.nn.Conv2d(
+            1, 32, kernel_size=(3, 3), stride=(2, 2), bias=False
+        )
+    # check input dtype
+    if generated_images.dtype != torch.float32:
+        generated_images = generated_images.float()
+    if real_images.dtype != torch.float32:
+        real_images = real_images.float()
+    if generated_images.max() > 1:
+        warnings.warn(
+            "Input generated images are not in [0, 1] range. "
+            "This may lead to incorrect results. "
+            "FID expects input images to be in [0, 1] range."
+            "Dividing the images by 255 for metric calculation."
+        )
+        generated_images = generated_images / 255.0
+    if real_images.max() > 1:
+        warnings.warn(
+            "Input real images are not in [0, 1] range. "
+            "This may lead to incorrect results. "
+            "FID expects input images to be in [0, 1] range."
+            "Dividing the images by 255 for metric calculation."
+        )
+        real_images = real_images / 255.0
+    fid_metric.update(generated_images, real=False)
+    fid_metric.update(real_images, real=True)
+    return fid_metric.compute()
+
+
+def _calculator_LPIPS(
+    generated_images: torch.Tensor,
+    real_images: torch.Tensor,
+    reduction: str,
+    n_input_channels: int,
+) -> torch.Tensor:
+    """This function computes the LPIPS between the generated images and the
+    real images. Except for the params specified below, the rest of the params
+    are default from torchmetrics.
+    Args:
+        generated_images (torch.Tensor): The generated images.
+        real_images (torch.Tensor): The real images.
+        reduction (str): The reduction type.
+        n_input_channels (int): The number of input channels.
+    Returns:
+        torch.Tensor: The LPIP score.
+    """
+    lpips_metric = tm.image.lpip.LearnedPerceptualImagePatchSimilarity(
+        net="squeeze",
+        normalize=True,
+        reduction=reduction,
+    )
+    if n_input_channels == 1:
+        # need manual patching for single channel data
+        lpips_metric.net.net.slices._modules["0"]._modules[
+            "0"
+        ] = torch.nn.Conv2d(
+            1,
+            64,
+            kernel_size=(3, 3),
+            stride=(2, 2),
+        )
+    # check input dtype
+    if generated_images.dtype != torch.float32:
+        generated_images = generated_images.float()
+    if real_images.dtype != torch.float32:
+        real_images = real_images.float()
+    if generated_images.max() > 1:
+        warnings.warn(
+            "Input generated images are not in [0, 1] range. "
+            "This may lead to incorrect results. "
+            "LPIPS expects input images to be in [0, 1] range."
+            "Dividing the images by 255 for metric calculation."
+        )
+        generated_images = generated_images / 255.0
+    if real_images.max() > 1:
+        warnings.warn(
+            "Input real images are not in [0, 1] range. "
+            "This may lead to incorrect results. "
+            "LPIPS expects input images to be in [0, 1] range."
+            "Dividing the images by 255 for metric calculation."
+        )
+        real_images = real_images / 255.0
+    return lpips_metric(generated_images, real_images)

--- a/setup.py
+++ b/setup.py
@@ -106,6 +106,8 @@ requirements = [
     "medcam",
     "opencv-python",
     "torchmetrics==1.1.2",
+    "torch-fidelity",
+    "lpips",
     "zarr==2.10.3",
     "pydicom",
     "onnx",


### PR DESCRIPTION
Fixes #763

## Proposed Changes
- implemened lpips metric working for 2d and 3d data
- implemented fid metric, but it only works for 2D data
- started implementing new calculator functions compatibile with GANDLF 
- tests still need to be implemented

## Checklist

Note that if a box is left unchecked, PR merges will take longer than usual.

- [X] I have read the [`CONTRIBUTING`](https://github.com/mlcommons/GaNDLF/blob/master/CONTRIBUTING.md) guide.
- [X] My PR is based from the [current GaNDLF master ](https://docs.github.com/en/desktop/contributing-and-collaborating-using-github-desktop/keeping-your-local-repository-in-sync-with-github/syncing-your-branch-in-github-desktop?platform=windows).
- [X] Non-breaking change (does **not** break existing functionality): provide **as many** details as possible for _any_ breaking change.
- [] Function/class source code documentation added/updated.
- [X] Code has been [blacked](https://github.com/psf/black#usage) for style consistency.
- [ ] If applicable, version information [has been updated in GANDLF/version.py](https://github.com/mlcommons/GaNDLF/blob/master/GANDLF/version.py).
- [ ] If adding a git submodule, add to list of exceptions for black styling in [pyproject.toml](https://github.com/mlcommons/GaNDLF/blob/master/pyproject.toml) file.
- [ ] [Usage documentation](https://github.com/mlcommons/GaNDLF/blob/master/docs) has been updated, if appropriate.
- [ ] Tests added or modified to [cover the changes](https://app.codecov.io/gh/mlcommons/GaNDLF); if coverage is reduced, please give explanation.
- [X] If customized dependency installation is required (i.e., a separate `pip install` step is needed for PR to be functional), please ensure it is reflected in all the files that control the CI, namely: [python-test.yml](https://github.com/mlcommons/GaNDLF/blob/master/.github/workflows/python-test.yml), and all docker files [[1](https://github.com/mlcommons/GaNDLF/blob/master/Dockerfile-CPU),[2](https://github.com/mlcommons/GaNDLF/blob/devcontainer_build_fix/Dockerfile-CUDA11.6),[3](https://github.com/mlcommons/GaNDLF/blob/master/Dockerfile-ROCm)].
